### PR TITLE
Fix whois server info of 43.0.0.0/8

### DIFF
--- a/ip_del_list
+++ b/ip_del_list
@@ -18,9 +18,7 @@
 37.0.0.0/8	ripe
 39.0.0.0/8	apnic
 41.0.0.0/8	afrinic
-42.0.0.0/8	apnic
-43.224.0.0/11	apnic
-43.0.0.0/8	whois.nic.ad.jp
+42.0.0.0/7	apnic
 46.0.0.0/8	ripe
 49.0.0.0/8	apnic
 51.0.0.0/8	ripe


### PR DESCRIPTION
Most of the IPs in NET43 (43.0.0.0/8) is managed by APNIC instead of JPNIC.